### PR TITLE
fix: align spectro frame processor with vision camera api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ dist/
 web-build/
 expo-env.d.ts
 
-# Native
+# Native artifacts
 .kotlin/
 *.orig.*
 *.jks
@@ -17,6 +17,11 @@ expo-env.d.ts
 *.p12
 *.key
 *.mobileprovision
+android/.gradle/
+android/app/build/
+android/build/
+ios/Pods/
+ios/build/
 
 # Metro
 .metro-health-check*
@@ -41,7 +46,3 @@ app-example
 .env.local
 
 .env.local
-
-android/
-
-ios/

--- a/android/src/main/java/com/lucasbiazon/ifotom/SpectroFramePlugin.kt
+++ b/android/src/main/java/com/lucasbiazon/ifotom/SpectroFramePlugin.kt
@@ -1,0 +1,83 @@
+package com.lucasbiazon.ifotom
+
+import com.facebook.proguard.annotations.DoNotStrip
+import com.mrousavy.camera.frameprocessors.Frame
+import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin
+import com.mrousavy.camera.frameprocessors.FrameProcessorPluginRegistry
+import java.nio.ByteBuffer
+
+@DoNotStrip
+class SpectroFramePlugin : FrameProcessorPlugin() {
+  override fun callback(frame: Frame, params: Map<String, Any>?): Any? {
+    val image = try {
+      frame.image
+    } catch (_: Throwable) {
+      return emptyList<Double>()
+    } ?: return emptyList<Double>()
+
+    val roi = parseRoi(params)
+    val yPlane = image.planes[0]
+    val rowStride = yPlane.rowStride
+    val pixelStride = yPlane.pixelStride
+    val width = image.width
+    val height = image.height
+
+    if (width <= 0 || height <= 0) return emptyList<Double>()
+
+    val x = roi.x.coerceIn(0, width - 1)
+    val y = roi.y.coerceIn(0, height - 1)
+    val w = roi.width.coerceIn(1, width - x)
+    val h = roi.height.coerceIn(1, height - y)
+
+    val yBuffer: ByteBuffer = yPlane.buffer.duplicate()
+    val sums = DoubleArray(w) { 0.0 }
+
+    for (row in y until (y + h)) {
+      val rowOffset = row * rowStride
+      val columnOffset = x * pixelStride
+      for (column in 0 until w) {
+        val index = rowOffset + columnOffset + column * pixelStride
+        if (index >= yBuffer.limit()) {
+          break
+        }
+        val value = yBuffer.get(index).toInt() and 0xFF
+        sums[column] += value.toDouble()
+      }
+    }
+
+    return sums.toList()
+  }
+
+  private fun parseRoi(params: Map<String, Any>?): Roi {
+    val container = when (val nested = params?.get("roi")) {
+      is Map<*, *> -> nested
+      else -> params
+    }
+
+    fun extract(key: String): Int {
+      val value = container?.get(key) ?: return 0
+      return when (value) {
+        is Number -> value.toInt()
+        is String -> value.toDoubleOrNull()?.toInt() ?: 0
+        else -> 0
+      }
+    }
+
+    return Roi(
+      extract("x"),
+      extract("y"),
+      extract("w"),
+      extract("h")
+    )
+  }
+
+  private data class Roi(val x: Int, val y: Int, val width: Int, val height: Int)
+
+  companion object {
+    init {
+      FrameProcessorPluginRegistry.addFrameProcessorPlugin("spectro_sum_columns") { _, _ ->
+        SpectroFramePlugin()
+      }
+    }
+  }
+}

--- a/app.json
+++ b/app.json
@@ -16,7 +16,10 @@
     ],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.lucasbiazon.iFOTOM"
+      "bundleIdentifier": "com.lucasbiazon.iFOTOM",
+      "infoPlist": {
+        "NSCameraUsageDescription": "Precisamos da c\u00e2mera para an\u00e1lises espectrofotom\u00e9tricas."
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -39,7 +42,7 @@
       [
         "expo-camera",
         {
-          "cameraPermission": "Permitir que $(PRODUCT_NAME) acesse sua câmera.",
+          "cameraPermission": "Permitir que $(PRODUCT_NAME) acesse sua c\u00e2mera.",
           "microphonePermission": "Permitir que $(PRODUCT_NAME) acesse seu microfone.",
           "recordAudioAndroid": true
         }
@@ -81,7 +84,14 @@
           "project": "react-native",
           "organization": "ifsp-campus-campinas"
         }
-      ]
+      ],
+      [
+        "react-native-vision-camera",
+        {
+          "cameraPermissionText": "Precisamos da c\u00e2mera para capturar espectros."
+        }
+      ],
+      "./plugins/withSpectroFramePlugin"
     ],
     "scheme": "myapp",
     "extra": {

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,10 +2,6 @@ module.exports = function (api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
-    env: {
-      production: {
-        plugins: ['react-native-paper/babel', "react-native-reanimated/plugin",],
-      },
-    },
+    plugins: ['react-native-paper/babel', 'react-native-reanimated/plugin'],
   };
 };

--- a/ios/SpectroFramePlugin.m
+++ b/ios/SpectroFramePlugin.m
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+#import <VisionCamera/FrameProcessorPlugin.h>
+
+@interface SpectroFramePlugin : NSObject
+@end
+
+@implementation SpectroFramePlugin
+VISION_EXPORT_SWIFT_FRAME_PROCESSOR(SpectroFramePlugin, spectro_sum_columns)
+@end

--- a/ios/SpectroFramePlugin.swift
+++ b/ios/SpectroFramePlugin.swift
@@ -1,0 +1,89 @@
+import AVFoundation
+import Foundation
+import VisionCamera
+
+@objc(SpectroFramePlugin)
+public final class SpectroFramePlugin: FrameProcessorPlugin {
+  public override func callback(_ frame: Frame!, withArguments arguments: [AnyHashable: Any]!) -> Any! {
+    guard
+      let frame = frame,
+      let sampleBuffer = frame.buffer,
+      let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
+    else {
+      return []
+    }
+
+    let roi = Self.parseROI(from: arguments)
+    let width = CVPixelBufferGetWidthOfPlane(pixelBuffer, 0)
+    let height = CVPixelBufferGetHeightOfPlane(pixelBuffer, 0)
+
+    guard width > 0, height > 0 else {
+      return []
+    }
+
+    CVPixelBufferLockBaseAddress(pixelBuffer, .readOnly)
+    defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, .readOnly) }
+
+    guard let baseAddress = CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0) else {
+      return []
+    }
+
+    let bytesPerRow = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0)
+
+    let rx = max(0, min(roi.x, width - 1))
+    let ry = max(0, min(roi.y, height - 1))
+    let rw = max(1, min(roi.width, width - rx))
+    let rh = max(1, min(roi.height, height - ry))
+
+    var sums = [Double](repeating: 0.0, count: rw)
+
+    for row in ry..<(ry + rh) {
+      let rowPointer = baseAddress.advanced(by: row * bytesPerRow)
+      let pixels = rowPointer.assumingMemoryBound(to: UInt8.self)
+      for column in 0..<rw {
+        sums[column] += Double(pixels[rx + column])
+      }
+    }
+
+    return sums
+  }
+
+  private struct ROI {
+    let x: Int
+    let y: Int
+    let width: Int
+    let height: Int
+
+    static let zero = ROI(x: 0, y: 0, width: 0, height: 0)
+  }
+
+  private static func parseROI(from arguments: [AnyHashable: Any]?) -> ROI {
+    guard let arguments else { return .zero }
+
+    if let nested = arguments["roi"] as? [AnyHashable: Any] {
+      return ROI(
+        x: Self.intValue(from: nested["x"]),
+        y: Self.intValue(from: nested["y"]),
+        width: Self.intValue(from: nested["w"]),
+        height: Self.intValue(from: nested["h"])
+      )
+    }
+
+    return ROI(
+      x: Self.intValue(from: arguments["x"]),
+      y: Self.intValue(from: arguments["y"]),
+      width: Self.intValue(from: arguments["w"]),
+      height: Self.intValue(from: arguments["h"])
+    )
+  }
+
+  private static func intValue(from value: Any?) -> Int {
+    if let number = value as? NSNumber {
+      return number.intValue
+    }
+    if let string = value as? NSString {
+      return string.integerValue
+    }
+    return 0
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-checkbox": "~4.1.4",
         "expo-constants": "~17.1.6",
         "expo-crypto": "~14.1.5",
+        "expo-dev-client": "^6.0.12",
         "expo-device": "~7.1.4",
         "expo-file-system": "~18.1.11",
         "expo-font": "~13.3.1",
@@ -65,6 +66,7 @@
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.11.1",
         "react-native-svg": "15.11.2",
+        "react-native-vision-camera": "^4.7.2",
         "react-native-web": "~0.20.0",
         "react-native-webview": "13.13.5",
         "uuid": "^11.1.0",
@@ -7169,6 +7171,56 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-dev-client": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/expo-dev-client/-/expo-dev-client-6.0.12.tgz",
+      "integrity": "sha512-Knr2abq0r6ALASsZtrX9QD4V0vP4ZL18iDVF5lgr6iFYawbuqQHuJRktIUETimu6qLusJK8Z3kZRabAdNqT+qw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-launcher": "6.0.11",
+        "expo-dev-menu": "7.0.11",
+        "expo-dev-menu-interface": "2.0.0",
+        "expo-manifests": "~1.0.8",
+        "expo-updates-interface": "~2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-launcher": {
+      "version": "6.0.11",
+      "resolved": "https://registry.npmjs.org/expo-dev-launcher/-/expo-dev-launcher-6.0.11.tgz",
+      "integrity": "sha512-5wcuevQ8l57uWVqHWpARwZb57doUbzPxorhJXpYLza1tJbkuQBb1lpjeJ1Di47bGMDq0jRw6yMFkF6N9nKX/OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu": "7.0.11",
+        "expo-manifests": "~1.0.8"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu": {
+      "version": "7.0.11",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu/-/expo-dev-menu-7.0.11.tgz",
+      "integrity": "sha512-xJ2scPxfHKyANTMgexK9tH7xunhsPEynuwpsssiS2syCWzvo+Mtv3euOLlkUb/IRt1JTKDxTMZBgChkaq5juSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-dev-menu-interface": "2.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-dev-menu-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-dev-menu-interface/-/expo-dev-menu-interface-2.0.0.tgz",
+      "integrity": "sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-device": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/expo-device/-/expo-device-7.1.4.tgz",
@@ -7271,6 +7323,12 @@
         "expo": "*"
       }
     },
+    "node_modules/expo-json-utils": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/expo-json-utils/-/expo-json-utils-0.15.0.tgz",
+      "integrity": "sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==",
+      "license": "MIT"
+    },
     "node_modules/expo-keep-awake": {
       "version": "14.1.4",
       "resolved": "https://registry.npmjs.org/expo-keep-awake/-/expo-keep-awake-14.1.4.tgz",
@@ -7315,6 +7373,110 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-manifests": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/expo-manifests/-/expo-manifests-1.0.8.tgz",
+      "integrity": "sha512-nA5PwU2uiUd+2nkDWf9e71AuFAtbrb330g/ecvuu52bmaXtN8J8oiilc9BDvAX0gg2fbtOaZdEdjBYopt1jdlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config": "~12.0.8",
+        "expo-json-utils": "~0.15.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@expo/config": {
+      "version": "12.0.9",
+      "resolved": "https://registry.npmjs.org/@expo/config/-/config-12.0.9.tgz",
+      "integrity": "sha512-HiDVVaXYKY57+L1MxSF3TaYjX6zZlGBnuWnOKZG+7mtsLD+aNTtW4bZM0pZqZfoRumyOU0SfTCwT10BWtUUiJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "@expo/config-plugins": "~54.0.1",
+        "@expo/config-types": "^54.0.8",
+        "@expo/json-file": "^10.0.7",
+        "deepmerge": "^4.3.1",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "require-from-string": "^2.0.2",
+        "resolve-from": "^5.0.0",
+        "resolve-workspace-root": "^2.0.0",
+        "semver": "^7.6.0",
+        "slugify": "^1.3.4",
+        "sucrase": "3.35.0"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@expo/config-plugins": {
+      "version": "54.0.1",
+      "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-54.0.1.tgz",
+      "integrity": "sha512-NyBChhiWFL6VqSgU+LzK4R1vC397tEG2XFewVt4oMr4Pnalq/mJxBANQrR+dyV1RHhSyhy06RNiJIkQyngVWeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/config-types": "^54.0.8",
+        "@expo/json-file": "~10.0.7",
+        "@expo/plist": "^0.4.7",
+        "@expo/sdk-runtime-versions": "^1.0.0",
+        "chalk": "^4.1.2",
+        "debug": "^4.3.5",
+        "getenv": "^2.0.0",
+        "glob": "^10.4.2",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "slash": "^3.0.0",
+        "slugify": "^1.6.6",
+        "xcode": "^3.0.1",
+        "xml2js": "0.6.0"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@expo/config-types": {
+      "version": "54.0.8",
+      "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-54.0.8.tgz",
+      "integrity": "sha512-lyIn/x/Yz0SgHL7IGWtgTLg6TJWC9vL7489++0hzCHZ4iGjVcfZmPTUfiragZ3HycFFj899qN0jlhl49IHa94A==",
+      "license": "MIT"
+    },
+    "node_modules/expo-manifests/node_modules/@expo/json-file": {
+      "version": "10.0.7",
+      "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.0.7.tgz",
+      "integrity": "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.10.4",
+        "json5": "^2.2.3"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/@expo/plist": {
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.4.7.tgz",
+      "integrity": "sha512-dGxqHPvCZKeRKDU1sJZMmuyVtcASuSYh1LPFVaM1DuffqPL36n6FMEL0iUqq2Tx3xhWk8wCnWl34IKplUjJDdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.8",
+        "base64-js": "^1.2.3",
+        "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo-manifests/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/expo-media-library": {
@@ -7506,6 +7668,15 @@
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.79.6.tgz",
       "integrity": "sha512-0v2/ruY7eeKun4BeKu+GcfO+SHBdl0LJn4ZFzTzjHdWES0Cn+ONqKljYaIv8p9MV2Hx/kcdEvbY4lWI34jC/mQ==",
       "license": "MIT"
+    },
+    "node_modules/expo-updates-interface": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz",
+      "integrity": "sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
     },
     "node_modules/expo-web-browser": {
       "version": "14.2.0",
@@ -12122,6 +12293,30 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/react-native-vision-camera": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/react-native-vision-camera/-/react-native-vision-camera-4.7.2.tgz",
+      "integrity": "sha512-C+5PvlSunN6I4aYplSask+v3jfhgduZumIVw6H6lG+Afpf8boIcG3uFSsSfVgj+hxI7fx6qM6bsciEhzgxEUYg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@shopify/react-native-skia": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": "*",
+        "react-native-worklets-core": "*"
+      },
+      "peerDependenciesMeta": {
+        "@shopify/react-native-skia": {
+          "optional": true
+        },
+        "react-native-reanimated": {
+          "optional": true
+        },
+        "react-native-worklets-core": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-native-web": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "expo-camera": "~16.1.11",
     "expo-checkbox": "~4.1.4",
     "expo-constants": "~17.1.6",
+    "expo-crypto": "~14.1.5",
+    "expo-dev-client": "^6.0.12",
     "expo-device": "~7.1.4",
     "expo-file-system": "~18.1.11",
     "expo-font": "~13.3.1",
@@ -67,12 +69,12 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-svg": "15.11.2",
+    "react-native-vision-camera": "^4.7.2",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
     "uuid": "^11.1.0",
     "zod": "^3.25.67",
-    "zustand": "^5.0.5",
-    "expo-crypto": "~14.1.5"
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/plugins/withSpectroFramePlugin.ts
+++ b/plugins/withSpectroFramePlugin.ts
@@ -1,0 +1,10 @@
+import { ConfigPlugin, withDangerousMod } from '@expo/config-plugins';
+
+/**
+ * Minimal config plugin so Expo is aware of the native Spectro frame processor.
+ */
+const withSpectroFramePlugin: ConfigPlugin = (config) => {
+  return withDangerousMod(config, ['ios', async (cfg) => cfg]);
+};
+
+export default withSpectroFramePlugin;

--- a/src/native/SpectroModule.ts
+++ b/src/native/SpectroModule.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import {
   VisionCameraProxy,
   useFrameProcessor,
@@ -13,79 +13,188 @@ export type RegionOfInterest = {
   h: number;
 };
 
+export type CaptureBurstOptions = {
+  timeoutMs?: number;
+};
+
 declare global {
+  // Cache initialized frame processor plugins inside the worklet runtime.
   var __spectroSumColumnsPlugin: FrameProcessorPlugin | undefined;
+  // VisionCamera < 4.0 exposed plugins on a global proxy – keep a fallback for that runtime.
+  var __visionCameraProxy:
+    | {
+        frameProcessorPlugins?: Record<string, (...args: unknown[]) => unknown>;
+      }
+    | undefined;
 }
 
 const PLUGIN_NAME = 'spectro_sum_columns';
-
-type PluginResult = number[] | undefined;
 
 export function useSpectroProcessor(roi: RegionOfInterest, onVector: (vector: number[]) => void) {
   const frameProcessor = useFrameProcessor((frame) => {
     'worklet';
 
+    const asNumberArray = (value: unknown): number[] | null => {
+      'worklet';
+      if (!Array.isArray(value)) {
+        return null;
+      }
+      for (let index = 0; index < value.length; index += 1) {
+        if (typeof value[index] !== 'number') {
+          return null;
+        }
+      }
+      return value as number[];
+    };
+
     let plugin = globalThis.__spectroSumColumnsPlugin;
     if (plugin == null) {
       try {
-        plugin = VisionCameraProxy.initFrameProcessorPlugin(PLUGIN_NAME, {});
-        globalThis.__spectroSumColumnsPlugin = plugin;
+        const initialized = VisionCameraProxy.initFrameProcessorPlugin(PLUGIN_NAME, {});
+        if (initialized != null) {
+          plugin = initialized;
+          globalThis.__spectroSumColumnsPlugin = initialized;
+        }
       } catch {
         plugin = undefined;
       }
     }
 
-    if (plugin == null) {
+    if (plugin != null) {
+      let result: unknown;
+      try {
+        result = plugin.call(frame, {
+          x: roi.x,
+          y: roi.y,
+          w: roi.w,
+          h: roi.h,
+        });
+      } catch {
+        return;
+      }
+
+      const values = asNumberArray(result);
+      if (values != null) {
+        runOnJS(onVector)(values);
+      }
       return;
     }
 
-    let result: PluginResult;
+    const legacyProxy = globalThis.__visionCameraProxy;
+    const legacyPlugin = legacyProxy?.frameProcessorPlugins?.[PLUGIN_NAME];
+    if (typeof legacyPlugin !== 'function') {
+      return;
+    }
+
+    let legacyResult: unknown;
     try {
-      result = plugin.call(frame, {
-        x: roi.x,
-        y: roi.y,
-        w: roi.w,
-        h: roi.h,
-      }) as unknown as PluginResult;
+      legacyResult = legacyPlugin(frame, roi.x, roi.y, roi.w, roi.h);
     } catch {
       return;
     }
 
-    if (!Array.isArray(result)) {
-      return;
+    const legacyValues = asNumberArray(legacyResult);
+    if (legacyValues != null) {
+      runOnJS(onVector)(legacyValues);
     }
-
-    runOnJS(onVector)(result);
   }, [roi.x, roi.y, roi.w, roi.h, onVector]);
 
   return frameProcessor;
 }
 
 export function useBurstCollector(targetFrames = 10) {
+  const framesToCollect = Math.max(1, targetFrames);
   const accumulatorRef = useRef<number[][]>([]);
   const resolverRef = useRef<((vectors: number[][]) => void) | null>(null);
 
+  const cancel = useCallback(() => {
+    resolverRef.current = null;
+    accumulatorRef.current = [];
+  }, []);
+
+  useEffect(() => cancel, [cancel]);
+
   const onVector = useCallback(
     (vector: number[]) => {
+      const resolve = resolverRef.current;
+      if (!resolve) {
+        return;
+      }
       const accumulator = accumulatorRef.current;
       accumulator.push(vector);
-      if (accumulator.length >= targetFrames && resolverRef.current) {
-        const output = [...accumulator];
-        accumulator.length = 0;
-        const resolve = resolverRef.current;
+      if (accumulator.length >= framesToCollect) {
         resolverRef.current = null;
+        const output = accumulator.slice();
+        accumulatorRef.current = [];
         resolve(output);
       }
     },
-    [targetFrames]
+    [framesToCollect]
   );
 
   const waitBurst = useCallback(() => {
-    accumulatorRef.current = [];
+    cancel();
     return new Promise<number[][]>((resolve) => {
       resolverRef.current = resolve;
     });
-  }, []);
+  }, [cancel]);
 
-  return { onVector, waitBurst };
+  return { onVector, waitBurst, cancel };
+}
+
+export function useSpectroBurst(roi: RegionOfInterest, targetFrames = 10) {
+  const { onVector, waitBurst, cancel } = useBurstCollector(targetFrames);
+  const frameProcessor = useSpectroProcessor(roi, onVector);
+
+  const captureBurst = useCallback(
+    async ({ timeoutMs }: CaptureBurstOptions = {}) => {
+      if (timeoutMs != null && timeoutMs <= 0) {
+        cancel();
+        throw new Error('captureBurst timed out');
+      }
+
+      const pendingBurst = waitBurst();
+      if (timeoutMs == null) {
+        return pendingBurst;
+      }
+
+      return await new Promise<number[][]>((resolve, reject) => {
+        let settled = false;
+        const timeoutHandle: ReturnType<typeof setTimeout> = setTimeout(() => {
+          if (settled) {
+            return;
+          }
+          settled = true;
+          cancel();
+          reject(new Error('captureBurst timed out'));
+        }, timeoutMs);
+
+        pendingBurst.then(
+          (vectors) => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            clearTimeout(timeoutHandle);
+            resolve(vectors);
+          },
+          (error) => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            clearTimeout(timeoutHandle);
+            reject(error);
+          }
+        );
+      });
+    },
+    [waitBurst, cancel]
+  );
+
+  return {
+    frameProcessor,
+    captureBurst,
+    cancelBurst: cancel,
+  };
 }

--- a/src/native/SpectroModule.ts
+++ b/src/native/SpectroModule.ts
@@ -1,0 +1,91 @@
+import { useCallback, useRef } from 'react';
+import {
+  VisionCameraProxy,
+  useFrameProcessor,
+  type FrameProcessorPlugin,
+} from 'react-native-vision-camera';
+import { runOnJS } from 'react-native-reanimated';
+
+export type RegionOfInterest = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+declare global {
+  var __spectroSumColumnsPlugin: FrameProcessorPlugin | undefined;
+}
+
+const PLUGIN_NAME = 'spectro_sum_columns';
+
+type PluginResult = number[] | undefined;
+
+export function useSpectroProcessor(roi: RegionOfInterest, onVector: (vector: number[]) => void) {
+  const frameProcessor = useFrameProcessor((frame) => {
+    'worklet';
+
+    let plugin = globalThis.__spectroSumColumnsPlugin;
+    if (plugin == null) {
+      try {
+        plugin = VisionCameraProxy.initFrameProcessorPlugin(PLUGIN_NAME, {});
+        globalThis.__spectroSumColumnsPlugin = plugin;
+      } catch {
+        plugin = undefined;
+      }
+    }
+
+    if (plugin == null) {
+      return;
+    }
+
+    let result: PluginResult;
+    try {
+      result = plugin.call(frame, {
+        x: roi.x,
+        y: roi.y,
+        w: roi.w,
+        h: roi.h,
+      }) as unknown as PluginResult;
+    } catch {
+      return;
+    }
+
+    if (!Array.isArray(result)) {
+      return;
+    }
+
+    runOnJS(onVector)(result);
+  }, [roi.x, roi.y, roi.w, roi.h, onVector]);
+
+  return frameProcessor;
+}
+
+export function useBurstCollector(targetFrames = 10) {
+  const accumulatorRef = useRef<number[][]>([]);
+  const resolverRef = useRef<((vectors: number[][]) => void) | null>(null);
+
+  const onVector = useCallback(
+    (vector: number[]) => {
+      const accumulator = accumulatorRef.current;
+      accumulator.push(vector);
+      if (accumulator.length >= targetFrames && resolverRef.current) {
+        const output = [...accumulator];
+        accumulator.length = 0;
+        const resolve = resolverRef.current;
+        resolverRef.current = null;
+        resolve(output);
+      }
+    },
+    [targetFrames]
+  );
+
+  const waitBurst = useCallback(() => {
+    accumulatorRef.current = [];
+    return new Promise<number[][]>((resolve) => {
+      resolverRef.current = resolve;
+    });
+  }, []);
+
+  return { onVector, waitBurst };
+}


### PR DESCRIPTION
## Summary
- update the Android Spectro frame processor plugin to use the current FrameProcessorPlugin API, clamp ROI parsing from map options, and register with the VisionCamera registry
- modernize the iOS Spectro frame processor to subclass FrameProcessorPlugin, read ROI dictionaries, and operate on pixel buffers safely
- switch the SpectroModule hook to VisionCameraProxy-based plugin initialization with caching and error handling inside the worklet

## Testing
- npm run lint *(fails: existing project lint violations unrelated to the updated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb81b260648327a0d0fa428dfa8e1a