### PR TITLE
Modernize Spectro frame processor integration

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="com.lucasbiazon.ifotom">
+  <application>
+    <provider
+      android:name="com.lucasbiazon.ifotom.SpectroInitProvider"
+      android:authorities="${applicationId}.spectro-init"
+      android:exported="false"
+      android:initOrder="1999" />
+  </application>
+</manifest>

--- a/android/src/main/java/com/lucasbiazon/ifotom/SpectroFramePlugin.kt
+++ b/android/src/main/java/com/lucasbiazon/ifotom/SpectroFramePlugin.kt
@@ -1,37 +1,43 @@
 package com.lucasbiazon.ifotom
 
+import android.graphics.Rect
 import android.media.Image
 import com.facebook.proguard.annotations.DoNotStrip
-import com.mrousavy.camera.frameprocessor.FrameProcessorPlugin
-import java.nio.ByteBuffer
+import com.mrousavy.camera.frameprocessors.Frame
+import com.mrousavy.camera.frameprocessors.FrameProcessorPlugin
+import com.mrousavy.camera.frameprocessors.FrameProcessorPluginRegistry
+import kotlin.math.max
+import kotlin.math.min
 
 @DoNotStrip
-class SpectroFramePlugin : FrameProcessorPlugin("spectro_sum_columns") {
-  override fun callback(frame: com.mrousavy.camera.frameprocessor.Frame, params: Array<out Any>?): Any? {
-    val image: Image = frame.image ?: return emptyList<Double>()
-    val arguments = params ?: emptyArray()
-    val (rx, ry, rw, rh) = parseRoi(arguments)
+class SpectroFramePlugin : FrameProcessorPlugin() {
+  override fun callback(frame: Frame, params: Map<String, Any>?): Any? {
+    val image = try {
+      frame.image
+    } catch (error: Throwable) {
+      return emptyList<Double>()
+    } ?: return emptyList<Double>()
+    val roi = clampToBounds(params, image)
+    if (roi.width() <= 0 || roi.height() <= 0) {
+      return emptyList<Double>()
+    }
 
-    val yPlane = image.planes[0]
-    val yBuffer: ByteBuffer = yPlane.buffer
-    val rowStride = yPlane.rowStride
-    val pixelStride = yPlane.pixelStride
+    val plane = image.planes.firstOrNull() ?: return emptyList<Double>()
+    val buffer = plane.buffer
+    val rowStride = plane.rowStride
+    val pixelStride = plane.pixelStride
 
-    val width = image.width
-    val height = image.height
+    val width = roi.width()
+    val sums = DoubleArray(width)
 
-    val x = rx.coerceIn(0, width - 1)
-    val y = ry.coerceIn(0, height - 1)
-    val w = rw.coerceIn(1, width - x)
-    val h = rh.coerceIn(1, height - y)
-
-    val sums = DoubleArray(w) { 0.0 }
-
-    for (row in y until (y + h)) {
+    val limit = buffer.limit()
+    val startX = roi.left
+    for (row in roi.top until roi.bottom) {
       val rowOffset = row * rowStride
-      for (column in 0 until w) {
-        val index = rowOffset + (x + column) * pixelStride
-        val value = yBuffer.get(index).toInt() and 0xFF
+      for (column in 0 until width) {
+        val index = rowOffset + (startX + column) * pixelStride
+        if (index >= limit) continue
+        val value = buffer.get(index).toInt() and 0xFF
         sums[column] += value.toDouble()
       }
     }
@@ -39,15 +45,34 @@ class SpectroFramePlugin : FrameProcessorPlugin("spectro_sum_columns") {
     return sums.toList()
   }
 
-  private fun parseRoi(args: Array<out Any>): Quad {
-    if (args.size < 4) return Quad(0, 0, 0, 0)
-    return Quad(
-      (args[0] as Number).toInt(),
-      (args[1] as Number).toInt(),
-      (args[2] as Number).toInt(),
-      (args[3] as Number).toInt()
-    )
-  }
+  companion object {
+    private const val NAME = "spectro_sum_columns"
 
-  data class Quad(val x: Int, val y: Int, val w: Int, val h: Int)
+    /**
+     * Ensure the plugin is registered by touching the companion object from app startup code.
+     * A ContentProvider is bundled to trigger this automatically.
+     */
+    @JvmStatic
+    fun ensureRegistered() = Unit
+
+    init {
+      FrameProcessorPluginRegistry.addFrameProcessorPlugin(NAME) { _, _ ->
+        SpectroFramePlugin()
+      }
+    }
+
+    private fun clampToBounds(params: Map<String, Any>?, image: Image): Rect {
+      val roiMap = params?.get("roi") as? Map<*, *> ?: emptyMap<String, Any>()
+      val requestedX = (roiMap["x"] as? Number)?.toInt() ?: 0
+      val requestedY = (roiMap["y"] as? Number)?.toInt() ?: 0
+      val requestedW = (roiMap["width"] as? Number)?.toInt() ?: image.width
+      val requestedH = (roiMap["height"] as? Number)?.toInt() ?: image.height
+
+      val left = min(max(requestedX, 0), image.width)
+      val top = min(max(requestedY, 0), image.height)
+      val right = min(max(left + max(requestedW, 0), left), image.width)
+      val bottom = min(max(top + max(requestedH, 0), top), image.height)
+      return Rect(left, top, right, bottom)
+    }
+  }
 }

--- a/android/src/main/java/com/lucasbiazon/ifotom/SpectroInitProvider.kt
+++ b/android/src/main/java/com/lucasbiazon/ifotom/SpectroInitProvider.kt
@@ -1,0 +1,38 @@
+package com.lucasbiazon.ifotom
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+
+/**
+ * No-op ContentProvider that forces the SpectroFramePlugin companion to initialize during
+ * application startup so the frame processor is registered before it is requested.
+ */
+class SpectroInitProvider : ContentProvider() {
+  override fun onCreate(): Boolean {
+    SpectroFramePlugin.ensureRegistered()
+    return true
+  }
+
+  override fun query(
+    uri: Uri,
+    projection: Array<out String>?,
+    selection: String?,
+    selectionArgs: Array<out String>?,
+    sortOrder: String?
+  ): Cursor? = null
+
+  override fun getType(uri: Uri): String? = null
+
+  override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+
+  override fun delete(uri: Uri, selection: String?, selectionArgs: Array<out String>?): Int = 0
+
+  override fun update(
+    uri: Uri,
+    values: ContentValues?,
+    selection: String?,
+    selectionArgs: Array<out String>?
+  ): Int = 0
+}


### PR DESCRIPTION
## Summary
- Harden the Android Spectro frame processor by clamping ROIs, guarding pixel access, registering via `FrameProcessorPluginRegistry`, and adding a bootstrap ContentProvider + manifest entry so the plugin loads on startup.
- Update the iOS Spectro frame processor to subclass `FrameProcessorPlugin`, clamp ROI bounds, safely sum the luma plane, and export the plugin through `VISION_EXPORT_SWIFT_FRAME_PROCESSOR`.
- Rework the Spectro worklet helper to use `VisionCameraProxy` with cached plugin handles, ROI normalization, and graceful error handling inside the frame processor.

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68cb8eef7ed88327a6121ce7c56fd4ea