### PR TITLE
Guard analysis router replacements to prevent loops

### DIFF
--- a/app/(tabs)/analysis/create/params.tsx
+++ b/app/(tabs)/analysis/create/params.tsx
@@ -1,0 +1,3 @@
+import ParamsScreen from "@/src/screens/analysis/params";
+
+export default ParamsScreen;

--- a/app/(tabs)/analysis/create/processing.tsx
+++ b/app/(tabs)/analysis/create/processing.tsx
@@ -1,0 +1,3 @@
+import ProcessingScreen from "@/src/screens/analysis/processing";
+
+export default ProcessingScreen;

--- a/src/features/analysis/AnalysisStateRouter.tsx
+++ b/src/features/analysis/AnalysisStateRouter.tsx
@@ -1,53 +1,74 @@
 // src/features/analysis/AnalysisStateRouter.tsx
 import { useAnalysisMachine } from "@/src/hooks/AnalysisMachineProvider";
-import { router, usePathname } from "expo-router";
-import { useCallback, useEffect, useRef } from "react";
+import { router, usePathname, useRootNavigationState } from "expo-router";
+import { useEffect, useMemo, useRef } from "react";
+
+const stripRouteGroups = (p: string) => p.replace(/\/\([^/]+\)/g, "");
 
 const norm = (p: string) => {
   const base = p.split("?")[0].split("#")[0];
-  return base.endsWith("/") && base !== "/" ? base.slice(0, -1) : base;
+  const withoutGroups = stripRouteGroups(base);
+  const trimmed =
+    withoutGroups.endsWith("/") && withoutGroups !== "/"
+      ? withoutGroups.slice(0, -1)
+      : withoutGroups;
+  return trimmed.endsWith("/index") ? trimmed.slice(0, -6) : trimmed;
 };
-const inCreate = (p: string) =>
-  p.startsWith("/(tabs)/analysis/create/index") ||
-  p.startsWith("/analysis/create/index");
 
 export default function AnalysisStateRouter() {
   const { state } = useAnalysisMachine();
-  const path = usePathname();
+  const rawPath = usePathname();
+  const navigationState = useRootNavigationState();
 
-  const lastRef = useRef(norm(path));
-  const safeReplace = useCallback(
-    (to: string) => {
-      const toN = norm(to),
-        pN = norm(path);
-      if (toN === pN || lastRef.current === toN) return;
-      lastRef.current = toN;
-      router.replace(toN);
-    },
-    [path]
-  );
+  const isNavigationReady = Boolean(navigationState?.key);
+  const path = useMemo(() => rawPath ?? "/", [rawPath]);
+  const normalizedPath = useMemo(() => norm(path), [path]);
+  const lastReplacedPathRef = useRef(normalizedPath);
+
+  const target = useMemo(() => {
+    if (!normalizedPath.startsWith("/analysis/create")) return null;
+
+    if (state.matches("CHOOSE_TYPE")) return "/analysis/create";
+    if (state.matches("PARAMS")) return "/analysis/create/params";
+    if (state.matches("PREFLIGHT") || state.matches("DECIDE_CALIB_DEVICE"))
+      return "/analysis/create/preflight";
+    if (state.matches("CALIB_DEVICE")) return "/analysis/create/calibrate";
+    if (state.matches("CALIB_CURVE")) return "/analysis/create/baseline";
+    if (state.matches("BUILD_CURVE")) return "/analysis/create/build-curve";
+    if (
+      state.matches("DECIDE_CURVE") ||
+      state.matches("ACQ_DARK_NOISE") ||
+      state.matches("ACQ_WHITE_NOISE") ||
+      state.matches("ACQ_REF1") ||
+      state.matches("ACQ_SAMPLE") ||
+      state.matches("ACQ_REF2")
+    )
+      return "/analysis/create/measure";
+    if (state.matches("PROCESSING")) return "/analysis/create/processing";
+    if (
+      state.matches("RESULTS") ||
+      state.matches("QA_SAVE") ||
+      state.matches("DONE")
+    )
+      return "/analysis/create/result";
+
+    return null;
+  }, [normalizedPath, state.value]);
 
   useEffect(() => {
-    lastRef.current = norm(path);
-  }, [path]);
+    if (!isNavigationReady) return;
+    lastReplacedPathRef.current = normalizedPath;
+  }, [normalizedPath, isNavigationReady]);
 
   useEffect(() => {
-    const p = norm(path);
-    if (!inCreate(p)) return;
+    if (!isNavigationReady || !target) return;
 
-    if (state.matches("CHOOSE_TYPE"))
-      return safeReplace("/(tabs)/analysis/create/index");
-    if (state.matches("PARAMS"))
-      return safeReplace("/(tabs)/analysis/create/params");
-    if (state.matches("PREFLIGHT"))
-      return safeReplace("/(tabs)/analysis/create/preflight");
-    if (state.matches("ACQUIRE"))
-      return safeReplace("/(tabs)/analysis/create/acquire");
-    if (state.matches("PROCESSING"))
-      return safeReplace("/(tabs)/analysis/create/processing");
-    if (state.matches("RESULTS"))
-      return safeReplace("/(tabs)/analysis/create/result");
-  }, [state.value, path, safeReplace]);
+    const to = norm(target);
+    if (to === normalizedPath || lastReplacedPathRef.current === to) return;
+
+    lastReplacedPathRef.current = to;
+    router.replace(to);
+  }, [target, normalizedPath, isNavigationReady]);
 
   return null;
 }

--- a/src/features/analysis/AnalysisStateRouter.tsx
+++ b/src/features/analysis/AnalysisStateRouter.tsx
@@ -3,7 +3,8 @@ import { useAnalysisMachine } from "@/src/hooks/AnalysisMachineProvider";
 import { router, usePathname, useRootNavigationState } from "expo-router";
 import { useEffect, useMemo, useRef } from "react";
 
-const stripRouteGroups = (p: string) => p.replace(/\/\([^/]+\)/g, "");
+const stripRouteGroups = (p: string) =>
+  p.replace(/\/\([^/]+\)/g, "").replace(/\/{2,}/g, "/");
 
 const norm = (p: string) => {
   const base = p.split("?")[0].split("#")[0];

--- a/src/screens/analysis/params.tsx
+++ b/src/screens/analysis/params.tsx
@@ -5,7 +5,6 @@ import { ThemedInput } from "@/src/components/ui/ThemedInput";
 import { ThemedText } from "@/src/components/ui/ThemedText";
 import { useThemeValue } from "@/src/hooks/useThemeValue";
 import { useSettingsStore } from "@/src/store/settingsStore"; // <<< novo
-import { router } from "expo-router";
 import { useEffect, useMemo, useState } from "react";
 import { StyleSheet, Switch, View } from "react-native";
 import { useAnalysisMachine } from "../../hooks/AnalysisMachineProvider";
@@ -14,13 +13,6 @@ export default function ParamsScreen() {
   const { state, send } = useAnalysisMachine();
   const analysisType = state.context.analysisType;
   const tint = useThemeValue("tint");
-
-  // ✅ Guarda de rota – só fica aqui se a máquina disser que é PARAMS de quant
-  useEffect(() => {
-    if (!state.matches("PARAMS") || analysisType !== "quant") {
-      router.replace("/(tabs)/analysis/create/index");
-    }
-  }, [state.value, analysisType]);
 
   // Evita flash enquanto redireciona
   if (!state.matches("PARAMS") || analysisType !== "quant") return null;


### PR DESCRIPTION
## Summary
- normalize the current path separately from the raw pathname so redirects can compare like-for-like values
- memoize the computed target route and track the last replacement to suppress redundant router.replace calls that were re-entering the machine
- strip expo-router group segments so navigation comparisons use the canonical /analysis/create paths instead of bouncing between grouped and ungrouped routes

## Testing
- npm run lint *(fails: espectrometria-app@workspace:.: This package doesn't seem to be present in your lockfile in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e15ac43cd083278e5e9b567ef06106